### PR TITLE
Fix - added new css variable --embed-border-start to no-embed-border class

### DIFF
--- a/Vault/.obsidian/snippets/CyanVoxel's General Tweaks.css
+++ b/Vault/.obsidian/snippets/CyanVoxel's General Tweaks.css
@@ -55,6 +55,10 @@ img {
   --embed-border-start: 0px solid black !important;
 }
 
+.no-embed-title .embed-title.markdown-embed-title {
+  display: none;
+}
+
 /* .markdown-preview-view */
 .markdown-preview-view {
   border-radius: 6px;

--- a/Vault/.obsidian/snippets/CyanVoxel's General Tweaks.css
+++ b/Vault/.obsidian/snippets/CyanVoxel's General Tweaks.css
@@ -52,6 +52,7 @@ img {
 
 .no-embed-border {
   --embed-border-left: 0px solid black !important;
+  --embed-border-start: 0px solid black !important;
 }
 
 /* .markdown-preview-view */


### PR DESCRIPTION
On my system, the `no-embed-border` CSS class wasn't working initially. 

The issue was that Obsidian was using a different CSS variable than expected. I added the correct variable, 
and now it's working as intended.

I think it's because of an Obsidian update, but I'm not quite sure.

You might also want to add --embed-padding: 0px !important; below to remove the padding, making it flush with the page border.

This is how it looks now with the additional changes.
![image](https://github.com/user-attachments/assets/b2a3e529-3ce5-4521-aef0-245e1af9ea11)

I also added the `no-embed-title` class to hide the embed title for a cleaner look, like this:
![image](https://github.com/user-attachments/assets/5d89b0db-69c9-468a-9850-f278ad4dc221)
